### PR TITLE
Add Dockerfile for building a Docker image of Farmer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Builds a docker image for https://github.com/Storj/downstream-farmer
+
+FROM debian:wheezy
+MAINTAINER Storj - http://storj.io/ - https://github.com/Storj
+
+# installs dependencies, builds farmer, removes unneeded dependencies to keep the image small
+RUN buildDeps='git build-essential python-pip'; \
+	pythonDeps='python-dev libcrypto++-dev libgmp-dev python-pkg-resources'; \
+	set -x \
+	&& apt-get update && apt-get install -y $buildDeps $pythonDeps --no-install-recommends \
+	&& pip install downstream-farmer \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+# when running, assume working path for farmer has been mounted from the host system at this location
+WORKDIR /downstream
+
+CMD ["downstream"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+Docker image for Downstream Farmer
+
+Usage
+===
+1. If you've never used Docker before. Check out the installation and basic usage guides and videos [here](https://docs.docker.com/installation/).
+
+2. Pull the Docker image:
+```docker pull storj/downstream-farmer```
+
+3. In your Farmer directory (on your Docker host), create file ```data/identities.json``` per the [instructions](https://github.com/Storj/downstream-farmer/wiki/Test-Group-A-FAQ).
+
+4. Run
+```docker run -d -v <path to your farmer directory>:/downstream storj/downstream-farmer```
+
+* Check the container status:
+```docker ps```
+
+* View the Farmer console output:
+```docker attach <container id|name>```
+
+Build Image from Source
+===
+```
+git clone git@github.com:Storj/downstream-farmer.git
+cd docker
+docker build .
+```


### PR DESCRIPTION
- creates a Docker image based of Debian Wheezy (for compactness)
- only keeps dependencies that are necessary after install is complete
- implementation migrated from prototype at
    https://github.com/tcoffin/storj-docker.git